### PR TITLE
Switched to OpenJDK8 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
Looks like the Travis config is broken... Travis dropped support for OracleJDK. This should fix the issue.