### PR TITLE
Add draft to show how tags could be unit tested

### DIFF
--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -45,5 +45,10 @@
       <artifactId>mvc-toolbox-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/jsp/src/main/java/de/chkal/mvctoolbox/jsp/HtmlWriter.java
+++ b/jsp/src/main/java/de/chkal/mvctoolbox/jsp/HtmlWriter.java
@@ -3,16 +3,22 @@ package de.chkal.mvctoolbox.jsp;
 import jakarta.servlet.jsp.JspContext;
 import jakarta.servlet.jsp.JspWriter;
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 
 public class HtmlWriter {
 
-  private final JspWriter writer;
+  private final Writer writer;
 
   public HtmlWriter(JspContext context) {
     this(context.getOut());
   }
 
   public HtmlWriter(JspWriter writer) {
+    this.writer = writer;
+  }
+
+  public HtmlWriter(final StringWriter writer) {
     this.writer = writer;
   }
 
@@ -57,5 +63,18 @@ public class HtmlWriter {
   public HtmlWriter write(String text) throws IOException {
     writer.write(text);
     return this;
+  }
+
+  /**
+   * Returns the output of the {@link #writer} if possible.
+   *
+   * @return the output as String when {@link #writer} is a {@link StringWriter} or <code>null</code> in any other case
+   */
+  public String getOutput() {
+    if (writer instanceof StringWriter) {
+      return writer.toString();
+    } else {
+      return null;
+    }
   }
 }

--- a/jsp/src/main/java/de/chkal/mvctoolbox/jsp/tag/CsrfTag.java
+++ b/jsp/src/main/java/de/chkal/mvctoolbox/jsp/tag/CsrfTag.java
@@ -14,14 +14,31 @@ import java.io.IOException;
  */
 public class CsrfTag extends DynamicBaseTag {
 
+	public static class Delegate {
+		private final String name;
+		private final String token;
+		private HtmlWriter writer;
+
+		public Delegate(final String name, final String token, final HtmlWriter writer) {
+			this.name = name;
+			this.token = token;
+			this.writer = writer;
+		}
+
+		public void run() throws IOException {
+			writer.beginStartTag("input")
+					.attribute("type", "hidden")
+					.attribute("name", name)
+					.attribute("value", token)
+					.selfClose();
+		}
+	}
+
 	@Override
 	public void doTag() throws JspException, IOException {
 		final HtmlWriter writer = new HtmlWriter(getJspContext());
+		final MvcContext mvcContext = getBean(MvcContext.class);
 
-		writer.beginStartTag("input")
-				.attribute("type", "hidden")
-				.attribute("name", getBean(MvcContext.class).getCsrf().getName())
-				.attribute("value", getBean(MvcContext.class).getCsrf().getToken())
-				.selfClose();
+		new Delegate(mvcContext.getCsrf().getName(), mvcContext.getCsrf().getToken(), writer).run();
 	}
 }

--- a/jsp/src/test/java/de/chkal/mvctoolbox/jsp/tag/CsrfTagTest.java
+++ b/jsp/src/test/java/de/chkal/mvctoolbox/jsp/tag/CsrfTagTest.java
@@ -1,0 +1,21 @@
+package de.chkal.mvctoolbox.jsp.tag;
+
+import de.chkal.mvctoolbox.jsp.HtmlWriter;
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertEquals;
+
+public class CsrfTagTest {
+
+	@Test
+	public void doTagShouldReturnCorrectRenderedValue() throws Exception {
+		final HtmlWriter writer = new HtmlWriter(new StringWriter());
+
+		final CsrfTag.Delegate sut = new CsrfTag.Delegate("foo", "bar", writer);
+		sut.run();
+
+		assertEquals("<input type=\"hidden\" name=\"foo\" value=\"bar\"/>", writer.getOutput());
+	}
+}


### PR DESCRIPTION
I think this way we could at least unit-test our JSP tags by calling a delegate, which receives the required dynamic data as parameters and is decoupled from CDI or JSP.